### PR TITLE
Updating sqeazy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,7 +192,7 @@ dependencies
     compile ('net.halcyon:halcyon:[0.3.8, 0.4.0[')           {transitive=true;  changing= true}
 
     // Sqeazy:
-    compile ('net.sqeazy:sqeazy:[0.4.2, 0.5.0[')             {transitive= true; changing= true}
+    compile ('net.sqeazy:sqeazy:0.5.2')             {transitive= true; changing= true}
 
     // CoreMem: 
     // transitively available via simbryo, clearvolume...

--- a/src/clearcontrol/stack/sourcesink/sink/SqeazyFileStackSink.java
+++ b/src/clearcontrol/stack/sourcesink/sink/SqeazyFileStackSink.java
@@ -146,7 +146,9 @@ public class SqeazyFileStackSink extends FileStackBase implements
                                                            lSourceShape,
                                                            lShape.length,
                                                            (Pointer<Byte>) mCompressedData.getBridJPointer(Byte.class),
-                                                           lEncodedBytes);
+                                                           lEncodedBytes,
+                                                           1// n_threads to use
+                     );
 
     if (lReturnValue != 0)
       throw new RuntimeException("Error while peforming sqy compression, error code:  "

--- a/src/clearcontrol/stack/sourcesink/sink/SqeazyFileStackSink.java
+++ b/src/clearcontrol/stack/sourcesink/sink/SqeazyFileStackSink.java
@@ -147,7 +147,7 @@ public class SqeazyFileStackSink extends FileStackBase implements
                                                            lShape.length,
                                                            (Pointer<Byte>) mCompressedData.getBridJPointer(Byte.class),
                                                            lEncodedBytes,
-                                                           1// n_threads to use
+                                                           1// number of threads
                      );
 
     if (lReturnValue != 0)

--- a/src/clearcontrol/stack/sourcesink/source/SqeazyFileStackSource.java
+++ b/src/clearcontrol/stack/sourcesink/source/SqeazyFileStackSource.java
@@ -135,7 +135,11 @@ public class SqeazyFileStackSource extends FileStackBase implements
       final int lReturnValue =
                              SqeazyLibrary.SQY_PipelineDecode_UI16(mCompressedBytes.getBridJPointer(Byte.class),
                                                                    lCompressedDataLength,
-                                                                   lDecodedBytes);
+                                                                   lDecodedBytes,
+                                                                   1// = number
+                                                                    // of
+                                                                    // threads
+                             );
 
       if (lReturnValue != 0)
         throw new RuntimeException("Error while peforming sqy compression, error code:  "

--- a/src/clearcontrol/stack/sourcesink/test/SqeazyFileStackTests.java
+++ b/src/clearcontrol/stack/sourcesink/test/SqeazyFileStackTests.java
@@ -142,7 +142,9 @@ public class SqeazyFileStackTests
                                                        lSourceShape,
                                                        3,
                                                        bCompressedData,
-                                                       lEncodedBytes));
+                                                       lEncodedBytes,
+                                                       1// = number of threads
+                 ));
 
     assertTrue(lEncodedBytes.getLong() > nil);
     assertTrue(lEncodedBytes.getLong() < lBufferLengthInByte);


### PR DESCRIPTION
- bumped the version of sqeazy which now obtains a binary that actually uses vectorised intructions. 
- the number of threads is hardcoded to 1 (this needs to change, what the API has to offer for this)
- the performance looks better `~100MB/s` but not perfect:
```
clearcontrol.stack.sourcesink.test.SqeazyFileStackTests > testWriteSpeed STANDARD_OUT
    /tmp/LocalFileStackTests0.3491803411896791
    generating data...
    size: 8388608 bytes!
    done generating data...
    start
    stop
    speed: 73.4665 MB/s
```
but using the [binary I now distribute with sqeazy on bintray](https://github.com/sqeazy/sqeazy/releases/tag/0.5.2) gives numbers just above 100 MB/s. A native build is 10x faster. I am looking into this.
