### PR TITLE
Make ham stack camera configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ sourceCompatibility = 1.8
 
 group = 'net.clearcontrol'
 
-version = '0.16.4' // getVersionName()
+version = '0.16.5' // getVersionName()
 
 test 
 {

--- a/src/clearcontrol/devices/cameras/devices/hamamatsu/HamStackCamera.java
+++ b/src/clearcontrol/devices/cameras/devices/hamamatsu/HamStackCamera.java
@@ -131,7 +131,7 @@ public class HamStackCamera extends
     getMaxWidthVariable().set(MachineConfiguration.get().getLongProperty("device.camera" + pCameraDeviceIndex +".imagewidthpixels", 2048L));
     getMaxHeightVariable().set(MachineConfiguration.get().getLongProperty("device.camera" + pCameraDeviceIndex +".imageheightpixels", 2048L));
 
-    getPixelSizeInMicrometersVariable().set(MachineConfiguration.get().getDoubleProperty("device.camera" + pCameraDeviceIndex +".pixelsizenm", 260.0));
+    getPixelSizeInMicrometersVariable().set(MachineConfiguration.get().getDoubleProperty("device.camera" + pCameraDeviceIndex +".pixelsizenm", 260.0) / 1000.0);
 
   }
 

--- a/src/clearcontrol/devices/cameras/devices/hamamatsu/HamStackCamera.java
+++ b/src/clearcontrol/devices/cameras/devices/hamamatsu/HamStackCamera.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import clearcontrol.core.concurrent.executors.AsynchronousExecutorFeature;
+import clearcontrol.core.configuration.MachineConfiguration;
 import clearcontrol.core.device.openclose.OpenCloseDeviceInterface;
 import clearcontrol.core.log.LoggingFeature;
 import clearcontrol.core.variable.Variable;
@@ -16,6 +17,7 @@ import clearcontrol.devices.cameras.TriggerTypeInterface;
 import clearcontrol.stack.EmptyStack;
 import clearcontrol.stack.StackInterface;
 import clearcontrol.stack.StackRequest;
+import com.android.dx.cf.code.Machine;
 import dcamj2.DcamDevice;
 import dcamj2.DcamLibrary;
 import dcamj2.DcamSequenceAcquisition;
@@ -123,13 +125,13 @@ public class HamStackCamera extends
     // ----------------------- done with the listener -------- //
 
     // for OrcaFlash 4.0:
-    getLineReadOutTimeInMicrosecondsVariable().set(9.74);
-    getBytesPerPixelVariable().set(2L);
+    getLineReadOutTimeInMicrosecondsVariable().set(MachineConfiguration.get().getDoubleProperty("device.camera" + pCameraDeviceIndex +".readouttimems", 9.74));
+    getBytesPerPixelVariable().set(MachineConfiguration.get().getLongProperty("device.camera" + pCameraDeviceIndex +".bytesperpixel", 2L));
 
-    getMaxWidthVariable().set(2048L);
-    getMaxHeightVariable().set(2048L);
+    getMaxWidthVariable().set(MachineConfiguration.get().getLongProperty("device.camera" + pCameraDeviceIndex +".imagewidthpixels", 2048L));
+    getMaxHeightVariable().set(MachineConfiguration.get().getLongProperty("device.camera" + pCameraDeviceIndex +".imageheightpixels", 2048L));
 
-    getPixelSizeInMicrometersVariable().set(260.0);
+    getPixelSizeInMicrometersVariable().set(MachineConfiguration.get().getDoubleProperty("device.camera" + pCameraDeviceIndex +".pixelsizenm", 260.0));
 
   }
 


### PR DESCRIPTION
With this change, the entries `device.camera0.pixelsizenm=260` are indeed read from the config file. Backwards compatibility is ensured but the config file should contain the correct value for the given microscope. Furthermore, in the given [LightSheet]Microscope implementation, the PixelSizeInMicrons variable must be copied/transferred from the Camera to the DetectionArms.