### PR TITLE
Fixes a NullPointerException deep inside ClearVolume / ClearGL

### DIFF
--- a/src/main/java/clearcontrol/gui/video/video2d/videowindow/VideoWindow.java
+++ b/src/main/java/clearcontrol/gui/video/video2d/videowindow/VideoWindow.java
@@ -94,10 +94,6 @@ public class VideoWindow implements AutoCloseable
     mEffectiveWindowHeight = pWindowHeight;
     mFlipX = pFlipX;
 
-    mClearGLDebugEventListener =
-                               new ClearGLDebugEventListenerForVideoWindow(this,
-                                                                           mFlipX);
-
     mClearGLWindow = new ClearGLWindow(pWindowName,
                                        pWindowWidth,
                                        pWindowHeight,


### PR DESCRIPTION
Hi Loic,

I had to remove some ClearGLDebugEventListenerForVideoWindow stuff, because it cause trouble on the XWing. When starting up, this exception was thrown:

```
Exception in thread "XWingGui-0-FPSAWTAnimator#02-Timer2" com.jogamp.opengl.util.AnimatorBase$UncaughtAnimatorException: com.jogamp.opengl.GLException: Caught NullPointerException: null on thread XW
ingGui-0-FPSAWTAnimator#02-Timer2
	at com.jogamp.opengl.util.AWTAnimatorImpl.display(AWTAnimatorImpl.java:92)
	at com.jogamp.opengl.util.AnimatorBase.display(AnimatorBase.java:452)
	at com.jogamp.opengl.util.FPSAnimator$MainTask.run(FPSAnimator.java:178)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)
Caused by: com.jogamp.opengl.GLException: Caught NullPointerException: null on thread XWingGui-0-FPSAWTAnimator#02-Timer2
	at com.jogamp.opengl.GLException.newGLException(GLException.java:76)
	at jogamp.opengl.GLDrawableHelper.invokeGLImpl(GLDrawableHelper.java:1327)
	at jogamp.opengl.GLDrawableHelper.invokeGL(GLDrawableHelper.java:1147)
	at com.jogamp.newt.opengl.GLWindow.display(GLWindow.java:759)
	at com.jogamp.opengl.util.AWTAnimatorImpl.display(AWTAnimatorImpl.java:81)
	... 4 more
Caused by: java.lang.NullPointerException
	at cleargl.GLShader.<init>(GLShader.java:77)
	at cleargl.GLProgram.buildProgram(GLProgram.java:25)
	at clearcontrol.gui.video.video2d.videowindow.ClearGLDebugEventListenerForVideoWindow.init(ClearGLDebugEventListenerForVideoWindow.java:91)
	at jogamp.opengl.GLDrawableHelper.init(GLDrawableHelper.java:644)
	at jogamp.opengl.GLDrawableHelper.init(GLDrawableHelper.java:667)
	at jogamp.opengl.GLAutoDrawableBase$1.run(GLAutoDrawableBase.java:431)
	at jogamp.opengl.GLDrawableHelper.invokeGLImpl(GLDrawableHelper.java:1291)
	... 7 more
```

Later, when starting 2D interactive imaging, this exception popped up:
```
java.lang.NullPointerException
	at clearcontrol.gui.video.video2d.videowindow.ClearGLDebugEventListenerForVideoWindow.display(ClearGLDebugEventListenerForVideoWindow.java:354)
	at jogamp.opengl.GLDrawableHelper.displayImpl(GLDrawableHelper.java:692)
	at jogamp.opengl.GLDrawableHelper.display(GLDrawableHelper.java:674)
	at jogamp.opengl.GLAutoDrawableBase$2.run(GLAutoDrawableBase.java:443)
	at jogamp.opengl.GLDrawableHelper.invokeGLImpl(GLDrawableHelper.java:1293)
	at jogamp.opengl.GLDrawableHelper.invokeGL(GLDrawableHelper.java:1147)
	at com.jogamp.newt.opengl.GLWindow.display(GLWindow.java:759)
	at jogamp.opengl.GLAutoDrawableBase.defaultWindowRepaintOp(GLAutoDrawableBase.java:215)
	at com.jogamp.newt.opengl.GLWindow.access$100(GLWindow.java:119)
	at com.jogamp.newt.opengl.GLWindow$2.windowRepaint(GLWindow.java:136)
	at jogamp.newt.WindowImpl.consumeWindowEvent(WindowImpl.java:4401)
	at jogamp.newt.WindowImpl.consumeEvent(WindowImpl.java:3372)
	at jogamp.newt.WindowImpl.doEvent(WindowImpl.java:3318)
	at jogamp.newt.WindowImpl.windowRepaint(WindowImpl.java:4715)
	at jogamp.newt.driver.windows.WindowDriver.reconfigureWindow0(Native Method)
	at jogamp.newt.driver.windows.WindowDriver.reconfigureWindowImpl(WindowDriver.java:248)
	at jogamp.newt.WindowImpl$SetPositionAction.run(WindowImpl.java:2893)
	at jogamp.newt.DisplayImpl.runOnEDTIfAvail(DisplayImpl.java:450)
	at jogamp.newt.WindowImpl.runOnEDTIfAvail(WindowImpl.java:2782)
	at jogamp.newt.WindowImpl.setPosition(WindowImpl.java:2911)
	at com.jogamp.newt.opengl.GLWindow.setPosition(GLWindow.java:510)
	at cleargl.ClearGLWindow.lambda$setWindowPosition$4(ClearGLWindow.java:243)
	at com.jogamp.common.util.RunnableTask.run(RunnableTask.java:127)
	at jogamp.newt.DefaultEDTUtil$NEDT.run(DefaultEDTUtil.java:375)
```

These exceptions are fixed when removing the ClearGLDebugEventListenerForVideoWindow as in this commit. I assume this DebugEventListener is not essential and we can leave it out?

Cheers,
Robert
